### PR TITLE
Add server-side recipe filters

### DIFF
--- a/src/services/api/recipes.js
+++ b/src/services/api/recipes.js
@@ -6,12 +6,13 @@ import apiClient from '../client';
  * @param {string|null} nextPageToken – token da próxima página (null na primeira chamada)
  * @returns {Promise<{ recipes: Array, nextPageToken: string|null }>}
  */
-  export const getRecipes = async (nextPageToken = null) => {
-    const res = await apiClient.get('/recipes', {
-      params: { nextPageToken }
-    });
-    return res.data; // { recipes, nextPageToken }
-  }
+export const getRecipes = async (nextPageToken = null, filters = {}) => {
+  const params = { nextPageToken };
+  if (filters.phase) params.phase = filters.phase;
+  if (filters.category) params.category = filters.category;
+  const res = await apiClient.get('/recipes', { params });
+  return res.data; // { recipes, nextPageToken }
+}
   // GET /recipes/:id
   export const getRecipeById = async id => {
     const res = await apiClient.get(`/recipes/${id}`);


### PR DESCRIPTION
## Summary
- extend `/recipes` API to support phase and category query params
- pass optional params from frontend API client
- support filtering on Recipes page and add dropdown for cycle phase

## Testing
- `npm test --silent --prefix .` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6845b7de510883278e209f0ad4808ce4