### PR TITLE
Add toast messages for protected routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,7 +34,7 @@ function App() {
           <Route path="/login" element={<AuthPage />} />
           <Route path="/signup" element={<AuthPage />} />
           <Route path="/profile" element={
-            <ProtectedRoute>
+            <ProtectedRoute message="Please log in to access your profile.">
               <Profile />
             </ProtectedRoute>
           } />
@@ -43,7 +43,7 @@ function App() {
           <Route
             path="/recipes/create"
             element={
-              <ProtectedRoute requireAdmin>
+              <ProtectedRoute requireAdmin message="Admin access required.">
                 <CreateRecipe />
               </ProtectedRoute>
             }
@@ -51,7 +51,7 @@ function App() {
           <Route
             path="/recipes/:id/edit"
             element={
-              <ProtectedRoute requireAdmin>
+              <ProtectedRoute requireAdmin message="Admin access required.">
                 <EditRecipe />
               </ProtectedRoute>
             }
@@ -61,7 +61,7 @@ function App() {
           <Route
             path="/meal-planner"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute message="Please log in to use the meal planner.">
                 <MealPlanner />
               </ProtectedRoute>
             }
@@ -69,7 +69,7 @@ function App() {
           <Route
             path="/meal-planner/:id"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute message="Please log in to view meal plan details.">
                 <MealPlanDetails />
               </ProtectedRoute>
             }
@@ -78,7 +78,7 @@ function App() {
           <Route
             path="/meal-planner/:id/edit"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute message="Please log in to edit meal plans.">
                 <EditMealPlanner />
               </ProtectedRoute>
             }
@@ -91,7 +91,7 @@ function App() {
           <Route
             path="/grocery-list"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute message="Please log in to view your grocery lists.">
                 <GroceryList />
               </ProtectedRoute>
             }
@@ -99,7 +99,7 @@ function App() {
           <Route
             path="/grocery-list/:id"
             element={
-              <ProtectedRoute>
+              <ProtectedRoute message="Please log in to view this grocery list.">
                 <GroceryListDetails />
               </ProtectedRoute>
             }
@@ -110,7 +110,7 @@ function App() {
           <Route
           path="/admin/ingredients"
           element={
-            <ProtectedRoute requireAdmin>
+            <ProtectedRoute requireAdmin message="Admin access required.">
               <ManageIngredients />
             </ProtectedRoute>
           }

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
+import { useToast } from '../context/ToastContext';
 
 /**
  * ProtectedRoute checks authentication and role, rendering children or navigating.
@@ -11,28 +12,29 @@ import { useAuth } from '../context/AuthContext';
  *   <Component />
  * </ProtectedRoute>
  */
-export function ProtectedRoute({ requireAdmin, children }) {
+export function ProtectedRoute({ requireAdmin, message, children }) {
   const { user, role, loading } = useAuth();
+  const { show } = useToast();
   const location = useLocation();
 
   // While auth state is loading
   if (loading) return null;
 
-  // If not logged in, alert and redirect to login
+  // If not logged in, show toast (if provided) and redirect to login
   if (!user) {
-    //alert('You must be logged in to view this page.');
+    if (message) show(message);
     return (
       <Navigate
         to="/login"
         replace
         state={{ from: location }}
       />
-    )
+    );
   }
 
-  // If admin role is required and user is not admin, alert and redirect to home
+  // If admin role is required and user is not admin, show toast and redirect
   if (requireAdmin && role !== 'admin') {
-    alert('You do not have permission to access this page.');
+    show(message || 'You do not have permission to access this page.');
     return <Navigate to="/" replace />;
   }
 

--- a/src/context/ToastContext.jsx
+++ b/src/context/ToastContext.jsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+const ToastContext = createContext();
+export const useToast = () => useContext(ToastContext);
+
+export function ToastProvider({ children }) {
+  const [toast, setToast] = useState(null);
+
+  const show = useCallback((message, duration = 3000) => {
+    setToast(message);
+    setTimeout(() => setToast(null), duration);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={{ show }}>
+      {children}
+      {toast && (
+        <div className="toast-container position-fixed top-0 end-0 p-3">
+          <div className="toast show">
+            <div className="toast-body">{toast}</div>
+          </div>
+        </div>
+      )}
+    </ToastContext.Provider>
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import './index.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './firebase';                  // Firebase bootstrap
 import { AuthProvider } from './context/AuthContext';  // note o plural “contexts”
+import { ToastProvider } from './context/ToastContext';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
@@ -14,7 +15,9 @@ const root = createRoot(container);
 root.render(
   <React.StrictMode>
     <AuthProvider>
-      <App />
+      <ToastProvider>
+        <App />
+      </ToastProvider>
     </AuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add a simple Toast context/provider
- wrap the application with ToastProvider
- extend `ProtectedRoute` with a `message` prop and show toast messages
- update routes to pass informative messages

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6845b7ecf1608327a8fe8521c789e479