### PR TITLE
Enable profile image upload

### DIFF
--- a/src/components/profile/ProfileAvatar.jsx
+++ b/src/components/profile/ProfileAvatar.jsx
@@ -1,7 +1,18 @@
 // src/components/profile/ProfileAvatar.jsx
-import React from 'react';
+import React, { useRef, useState, useEffect } from 'react';
+import { useToast } from '../../context/ToastContext';
+import { uploadUserAvatar } from '../../services/api/storage';
 
 export default function ProfileAvatar({ displayName, photoUrl }) {
+  const [avatarUrl, setAvatarUrl] = useState(photoUrl);
+  const [uploading, setUploading] = useState(false);
+  const fileInputRef = useRef(null);
+  const { show } = useToast();
+
+  useEffect(() => {
+    setAvatarUrl(photoUrl);
+  }, [photoUrl]);
+
   // Generate initials from display name
   const getInitials = (name) => {
     if (!name) return '?';
@@ -13,28 +24,71 @@ export default function ProfileAvatar({ displayName, photoUrl }) {
       .substring(0, 2);
   };
 
+  const handleSelectFile = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    if (!/^image\/(jpe?g|png|gif)$/.test(file.type)) {
+      show('Only image files are allowed');
+      return;
+    }
+    try {
+      setUploading(true);
+      const url = await uploadUserAvatar(file);
+      setAvatarUrl(url);
+      show('Profile photo updated');
+    } catch (err) {
+      console.error('Avatar upload error:', err);
+      show('Failed to upload photo');
+    } finally {
+      setUploading(false);
+    }
+  };
+
   return (
-    <div className="profile-avatar">
-      {photoUrl ? (
-        <img 
-          src={photoUrl} 
-          alt={displayName || 'User'} 
-          className="rounded-circle img-thumbnail" 
-          style={{ width: '150px', height: '150px', objectFit: 'cover' }}
+    <div className="profile-avatar text-center">
+      <input
+        type="file"
+        ref={fileInputRef}
+        accept="image/png,image/jpeg,image/jpg,image/gif"
+        style={{ display: 'none' }}
+        onChange={handleFileChange}
+      />
+
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt={displayName || 'User'}
+          className="rounded-circle img-thumbnail"
+          style={{ width: '150px', height: '150px', objectFit: 'cover', cursor: 'pointer' }}
+          onClick={handleSelectFile}
         />
       ) : (
-        <div 
+        <div
           className="rounded-circle d-flex justify-content-center align-items-center bg-primary text-white"
-          style={{ width: '150px', height: '150px', fontSize: '3rem', margin: '0 auto' }}
+          style={{ width: '150px', height: '150px', fontSize: '3rem', margin: '0 auto', cursor: 'pointer' }}
+          onClick={handleSelectFile}
         >
           {getInitials(displayName)}
         </div>
       )}
-      
+
       <div className="mt-3">
-        <button className="btn btn-outline-secondary">
-          <i className="bi bi-camera me-2"></i>
-          Upload Photo
+        <button className="btn btn-outline-secondary" onClick={handleSelectFile} disabled={uploading}>
+          {uploading ? (
+            <>
+              <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+              Uploading...
+            </>
+          ) : (
+            <>
+              <i className="bi bi-camera me-2"></i>
+              Upload Photo
+            </>
+          )}
         </button>
         <div className="form-text mt-2">
           Recommended: Square image, at least 200x200px

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -9,6 +9,10 @@ import {
   getFirestore,
   connectFirestoreEmulator
 } from 'firebase/firestore';
+import {
+  getStorage,
+  connectStorageEmulator
+} from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey:             process.env.REACT_APP_FIREBASE_API_KEY,
@@ -23,16 +27,19 @@ const firebaseConfig = {
 const app  = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db   = getFirestore(app);
+export const storage = getStorage(app);
 
 // Conecta ao Auth + Firestore emulador em dev local
 if (window.location.hostname === 'localhost') {
   connectAuthEmulator(auth, 'http://localhost:9099', { disableWarnings: true });
   connectFirestoreEmulator(db, 'localhost', 8080);
+  connectStorageEmulator(storage, 'localhost', 9199);
 }
 
 // Exponha no console para debug e testes manuais
 if (typeof window !== 'undefined') {
   window._auth   = auth;
+  window._storage = storage;
   window._signIn = (email, password) =>
     signInWithEmailAndPassword(auth, email, password);
 }

--- a/src/services/api/storage.js
+++ b/src/services/api/storage.js
@@ -1,0 +1,22 @@
+import { storage, db, auth } from '../../firebase';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { doc, updateDoc } from 'firebase/firestore';
+
+/**
+ * Uploads the given file as the user's avatar and updates the Firestore profile.
+ * @param {File} file - Image file to upload.
+ * @returns {Promise<string>} The download URL of the uploaded image.
+ */
+export const uploadUserAvatar = async (file) => {
+  const userId = auth.currentUser?.uid;
+  if (!userId) throw new Error('User not authenticated');
+
+  const ext = file.name.split('.').pop();
+  const storageRef = ref(storage, `avatars/${userId}.${ext}`);
+
+  await uploadBytes(storageRef, file);
+  const url = await getDownloadURL(storageRef);
+
+  await updateDoc(doc(db, 'users', userId), { photo_url: url });
+  return url;
+};


### PR DESCRIPTION
## Summary
- support Firebase Storage in firebase config
- add helper for uploading user avatars
- implement avatar upload in `ProfileAvatar` component

## Testing
- `npm test --silent` *(fails: auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_6846280e5e808327bc20576912d80534