### PR TITLE
Responsive toast positioning

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -165,3 +165,20 @@ main {
   margin-bottom: 20px;
   color: #007bff;
 }
+
+/* Responsive toast positioning */
+.toast-container-responsive {
+  top: 1rem;
+  right: 1rem;
+  z-index: 1100;
+}
+
+@media (max-width: 767.98px) {
+  .toast-container-responsive {
+    top: auto;
+    bottom: 1rem;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+}

--- a/src/context/ToastContext.jsx
+++ b/src/context/ToastContext.jsx
@@ -15,7 +15,7 @@ export function ToastProvider({ children }) {
     <ToastContext.Provider value={{ show }}>
       {children}
       {toast && (
-        <div className="toast-container position-fixed top-0 end-0 p-3">
+        <div className="toast-container position-fixed p-3 toast-container-responsive">
           <div className="toast show">
             <div className="toast-body">{toast}</div>
           </div>

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -4,4 +4,4 @@
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
 
-jest.mock('../firebase'); // path relativo de cada teste para src/firebase.js
+jest.mock('./firebase'); // mock Firebase for all tests


### PR DESCRIPTION
## Summary
- move toast container to a responsive CSS class
- style `.toast-container-responsive` for desktop top-right and mobile bottom-center
- fix jest firebase mock path

## Testing
- `npm test -- -w=1 --watchAll=false` *(fails: SyntaxError in CreateRecipe.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68488a302a748327908dd9fbd11c00f4